### PR TITLE
Added horizontal scroll bar, made hidden nodes only draw one grey lin…

### DIFF
--- a/ReClass/CChildView.h
+++ b/ReClass/CChildView.h
@@ -51,6 +51,7 @@ public:
 	afx_msg void OnPaint( );
 	afx_msg void OnSize( UINT nType, int cx, int cy );
 	afx_msg void OnVScroll( UINT nSBCode, UINT nPos, CScrollBar* pScrollBar );
+	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	afx_msg BOOL OnEraseBkgnd( CDC* pDC );
 	afx_msg BOOL OnMouseWheel( UINT nFlags, short zDelta, CPoint pt );
 	afx_msg void OnMouseHover( UINT nFlags, CPoint point );
@@ -224,6 +225,7 @@ public:
 	CCustomToolTip m_ToolTip;
 
 	CScrollBar m_Scroll;
+	CScrollBar m_HScroll;
 
 	bool isDeleting;
 };

--- a/ReClass/CNodeArray.cpp
+++ b/ReClass/CNodeArray.cpp
@@ -44,8 +44,10 @@ ULONG CNodeArray::GetMemorySize( )
 	return m_pNode->GetMemorySize( ) * m_dwTotal;
 }
 
-int CNodeArray::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeArray::Draw( ViewInfo & View, int x, int y )
 {
+	NodeSize drawnSize = { 0 };
+	NodeSize childDrawnSize;
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 	AddSelection( View, 0, y, g_FontHeight );
@@ -83,7 +85,13 @@ int CNodeArray::Draw( ViewInfo & View, int x, int y )
 		NewView = View;
 		NewView.Address = View.Address + m_Offset + m_pNode->GetMemorySize( ) * m_iCurrent;
 		NewView.pData = (UCHAR*)((ULONG_PTR)View.pData + m_Offset + m_pNode->GetMemorySize( ) * m_iCurrent);
-		y = m_pNode->Draw( NewView, x, y );
+		childDrawnSize = m_pNode->Draw( NewView, x, y );
+		y = childDrawnSize.y;
+		if (childDrawnSize.x > drawnSize.x) {
+			drawnSize.x = childDrawnSize.x;
+		}
 	};
-	return y;
+	
+	drawnSize.y = y;
+	return drawnSize;
 }

--- a/ReClass/CNodeArray.h
+++ b/ReClass/CNodeArray.h
@@ -9,7 +9,7 @@ public:
 
 	virtual ULONG GetMemorySize( );
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	void SetTotal( DWORD total ) { m_dwTotal = total; }
 	DWORD GetTotal( void ) { return m_dwTotal; }

--- a/ReClass/CNodeBase.cpp
+++ b/ReClass/CNodeBase.cpp
@@ -618,8 +618,10 @@ void CNodeBase::StandardUpdate( HotSpot &Spot )
 		m_strComment = Spot.Text;
 }
 
-int CNodeBase::DrawHidden( ViewInfo& View, int x, int y )
+NodeSize CNodeBase::DrawHidden( ViewInfo& View, int x, int y )
 {
+	NodeSize drawnSize = { 0 };
 	View.dc->FillSolidRect( 0, y, View.client->right, 1, (m_bSelected) ? g_crSelect : g_crHidden );
-	return y + 1;
+	drawnSize.y = y;
+	return drawnSize;
 }

--- a/ReClass/CNodeBase.h
+++ b/ReClass/CNodeBase.h
@@ -98,13 +98,18 @@ typedef struct _RTTI_COMPLETE_OBJECT_LOCATOR
 	#endif
 } RTTI_COMPLETE_OBJECT_LOCATOR, *PRTTI_COMPLETE_OBJECT_LOCATOR;
 
+struct NodeSize {
+	int x;
+	int y;
+};
+
 class CNodeBase
 {
 public:
 	CNodeBase( );
 	~CNodeBase( ) { }
 
-	virtual int Draw( ViewInfo& View, int x, int y ) = 0;
+	virtual NodeSize Draw( ViewInfo& View, int x, int y ) = 0;
 	virtual ULONG GetMemorySize( ) = 0;
 	virtual void Update( HotSpot& Spot ) = 0;
 
@@ -179,7 +184,7 @@ public:
 
 	void StandardUpdate( HotSpot &Spot );
 
-	int DrawHidden( ViewInfo& View, int x, int y );
+	NodeSize DrawHidden( ViewInfo& View, int x, int y );
 
 protected:
 	NodeType m_nodeType;

--- a/ReClass/CNodeBits.cpp
+++ b/ReClass/CNodeBits.cpp
@@ -16,9 +16,10 @@ void CNodeBits::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, 1 );
 }
 
-int CNodeBits::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeBits::Draw( ViewInfo & View, int x, int y )
 {
 	UCHAR* pMemory = NULL;
+	NodeSize drawnSize;
 
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
@@ -43,5 +44,7 @@ int CNodeBits::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crHex, 0, _T( "%0.2X" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeBits.h
+++ b/ReClass/CNodeBits.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return 1; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeByte.cpp
+++ b/ReClass/CNodeByte.cpp
@@ -14,10 +14,11 @@ void CNodeByte::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( unsigned char ) );
 }
 
-int CNodeByte::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeByte::Draw( ViewInfo & View, int x, int y )
 {
 	int tx = 0;
 	UCHAR* pMemory = NULL;
+	NodeSize drawnSize;
 
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
@@ -37,5 +38,7 @@ int CNodeByte::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%u" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeByte.h
+++ b/ReClass/CNodeByte.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( unsigned char ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeCharPtr.cpp
+++ b/ReClass/CNodeCharPtr.cpp
@@ -19,10 +19,11 @@ void CNodeCharPtr::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &ptr, sizeof( size_t ) );
 }
 
-int CNodeCharPtr::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeCharPtr::Draw( ViewInfo & View, int x, int y )
 {
 	int tx = 0;
 	ULONG_PTR* pMemory = NULL;
+	NodeSize drawnSize;
 
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
@@ -65,5 +66,7 @@ int CNodeCharPtr::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crChar, HS_NONE, _T( "' " ) ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeCharPtr.h
+++ b/ReClass/CNodeCharPtr.h
@@ -12,7 +12,7 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( void* ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 public:
 	CNodeBase* pNode;

--- a/ReClass/CNodeClass.cpp
+++ b/ReClass/CNodeClass.cpp
@@ -42,9 +42,11 @@ ULONG CNodeClass::GetMemorySize( )
 	return size;
 }
 
-int CNodeClass::Draw( ViewInfo& View, int x, int y )
+NodeSize CNodeClass::Draw( ViewInfo& View, int x, int y )
 {
-	AddSelection( View, 0, y, g_FontHeight );
+	NodeSize drawnSize = { 0 };
+	NodeSize childDrawnSize;
+	AddSelection( View, x, y, g_FontHeight );
 	x = AddOpenClose( View, x, y );
 
 	// Save tx here
@@ -67,15 +69,25 @@ int CNodeClass::Draw( ViewInfo& View, int x, int y )
 	x = AddText( View, x, y, g_crValue, HS_NONE, _T( "[%i]" ), GetMemorySize( ) ) + g_FontWidth;
 	x = AddComment( View, x, y );
 
+	
+	drawnSize.x = x;	
 	y += g_FontHeight;
 	if (m_LevelsOpen[View.Level])
 	{
 		ViewInfo nv;
 		nv = View;
 		nv.Level++;
-		for (UINT i = 0; i < Nodes.size( ); i++)
-			y = Nodes[i]->Draw( nv, tx, y );
+		
+		for (UINT i = 0; i < Nodes.size(); i++) {
+			childDrawnSize = Nodes[i]->Draw(nv, tx, y);
+			y = childDrawnSize.y;
+			if (childDrawnSize.x > drawnSize.x) {
+				drawnSize.x = childDrawnSize.x;
+			}
+
+		}			
 	}
 
-	return y;
+	drawnSize.y = y;
+	return drawnSize;
 }

--- a/ReClass/CNodeClass.h
+++ b/ReClass/CNodeClass.h
@@ -11,7 +11,7 @@ public:
 
 	virtual ULONG GetMemorySize( );
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	VOID SetChildFrame( class CChildFrame* pChild ) { pChildWindow = pChild; }
 	class CChildFrame* GetChildFrame(  ) { return pChildWindow; }

--- a/ReClass/CNodeClassInstance.cpp
+++ b/ReClass/CNodeClassInstance.cpp
@@ -17,11 +17,13 @@ ULONG CNodeClassInstance::GetMemorySize( )
 	return m_pNode->GetMemorySize( );
 }
 
-int CNodeClassInstance::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeClassInstance::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
+	NodeSize childDrawnSize;
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
 	AddTypeDrop( View, x, y );
@@ -47,8 +49,14 @@ int CNodeClassInstance::Draw( ViewInfo & View, int x, int y )
 		NewView = View;
 		NewView.Address = View.Address + m_Offset;
 		NewView.pData = (UCHAR*)((ULONG_PTR)NewView.pData + m_Offset);
-		y = m_pNode->Draw( NewView, x, y );
+		childDrawnSize = m_pNode->Draw( NewView, x, y );
+		y = childDrawnSize.y;
+		if (childDrawnSize.x > drawnSize.x) {
+			drawnSize.x = childDrawnSize.x;
+		}
 	}
 
-	return y;
+	drawnSize.x = tx;
+	drawnSize.y = y;
+	return drawnSize;
 }

--- a/ReClass/CNodeClassInstance.h
+++ b/ReClass/CNodeClassInstance.h
@@ -11,7 +11,7 @@ public:
 
 	virtual ULONG GetMemorySize( );
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	void SetClass( CNodeClass* pNode ) { m_pNode = pNode; }
 	CNodeClass* GetClass( void ) { return m_pNode; }

--- a/ReClass/CNodeCustom.cpp
+++ b/ReClass/CNodeCustom.cpp
@@ -20,11 +20,12 @@ ULONG CNodeCustom::GetMemorySize( )
 	return m_dwMemorySize;
 }
 
-int CNodeCustom::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeCustom::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
 	AddTypeDrop( View, x, y );
@@ -39,5 +40,8 @@ int CNodeCustom::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crIndex, HS_NONE, _T( "] " ) );
 	tx = AddText( View, tx, y, g_crName, HS_NAME, _T( "%s" ), m_strName ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
-	return y += g_FontHeight;
+	
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeCustom.h
+++ b/ReClass/CNodeCustom.h
@@ -11,7 +11,7 @@ public:
 
 	virtual ULONG GetMemorySize( );
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	void SetSize( DWORD size ) { m_dwMemorySize = size; }
 	DWORD GetSize( void ) { return m_dwMemorySize; }

--- a/ReClass/CNodeDWORD.cpp
+++ b/ReClass/CNodeDWORD.cpp
@@ -14,11 +14,12 @@ void CNodeDWORD::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( unsigned long ) );
 }
 
-int CNodeDWORD::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeDWORD::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	DWORD* pMemory = (DWORD*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -34,5 +35,7 @@ int CNodeDWORD::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%u" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeDWORD.h
+++ b/ReClass/CNodeDWORD.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( unsigned long ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeDouble.cpp
+++ b/ReClass/CNodeDouble.cpp
@@ -14,11 +14,12 @@ void CNodeDouble::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, 8 );
 }
 
-int CNodeDouble::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeDouble::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	double* pMemory = (double*)&View.pData[m_Offset];
 
 	AddSelection( View, 0, y, g_FontHeight );
@@ -36,5 +37,7 @@ int CNodeDouble::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%.4g" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeDouble.h
+++ b/ReClass/CNodeDouble.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( void ) { return sizeof( double ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeFloat.cpp
+++ b/ReClass/CNodeFloat.cpp
@@ -14,11 +14,12 @@ void CNodeFloat::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, 4 );
 }
 
-int CNodeFloat::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeFloat::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	float* pMemory = (float*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -39,5 +40,7 @@ int CNodeFloat::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%4.3f" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeFloat.h
+++ b/ReClass/CNodeFloat.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( float ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeFunction.cpp
+++ b/ReClass/CNodeFunction.cpp
@@ -49,11 +49,12 @@ void CNodeFunction::Update( HotSpot& Spot )
 	}
 }
 
-int CNodeFunction::Draw( ViewInfo& View, int x, int y )
+NodeSize CNodeFunction::Draw( ViewInfo& View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
 	AddTypeDrop( View, x, y );
@@ -107,7 +108,9 @@ int CNodeFunction::Draw( ViewInfo& View, int x, int y )
 		y += g_FontHeight;
 	}
 
-	return y;
+	drawnSize.x = tx;
+	drawnSize.y = y;
+	return drawnSize;
 }
 
 void CNodeFunction::Initialize( CChildView* pChild, ULONG_PTR Address )

--- a/ReClass/CNodeFunction.h
+++ b/ReClass/CNodeFunction.h
@@ -14,7 +14,7 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return m_dwMemorySize; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	void Initialize( CChildView* pChild, ULONG_PTR Address );
 

--- a/ReClass/CNodeFunctionPtr.cpp
+++ b/ReClass/CNodeFunctionPtr.cpp
@@ -49,8 +49,9 @@ void CNodeFunctionPtr::Update( HotSpot& Spot )
 	}
 }
 
-int CNodeFunctionPtr::Draw( ViewInfo& View, int x, int y )
+NodeSize CNodeFunctionPtr::Draw( ViewInfo& View, int x, int y )
 {
+	NodeSize drawnSize;
 	int tx = 0;
 	int ax = 0;
 
@@ -129,7 +130,9 @@ int CNodeFunctionPtr::Draw( ViewInfo& View, int x, int y )
 		y += g_FontHeight;
 	}
 
-	return y;
+	drawnSize.x = tx;
+	drawnSize.y = y;
+	return drawnSize;
 }
 
 void CNodeFunctionPtr::Initialize( CChildView* pChild, ULONG_PTR Address )

--- a/ReClass/CNodeFunctionPtr.h
+++ b/ReClass/CNodeFunctionPtr.h
@@ -14,7 +14,7 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( void* ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	void Initialize( CChildView* pChild, ULONG_PTR Address );
 

--- a/ReClass/CNodeHex16.cpp
+++ b/ReClass/CNodeHex16.cpp
@@ -16,11 +16,12 @@ void CNodeHex16::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)(Spot.Address + 1), &v, 1 );
 }
 
-int CNodeHex16::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeHex16::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	unsigned char* pMemory = (unsigned char*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -41,5 +42,7 @@ int CNodeHex16::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crHex, 1, _T( "%0.2X" ), pMemory[1] & 0xFF ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeHex16.h
+++ b/ReClass/CNodeHex16.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return 2; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeHex32.cpp
+++ b/ReClass/CNodeHex32.cpp
@@ -14,11 +14,12 @@ void CNodeHex32::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)(Spot.Address + Spot.ID), &v, 1 );
 }
 
-int CNodeHex32::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeHex32::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	unsigned char* pMemory = (unsigned char*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -42,5 +43,7 @@ int CNodeHex32::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crHex, 3, _T( "%0.2X" ), pMemory[3] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeHex32.h
+++ b/ReClass/CNodeHex32.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return 4; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeHex64.cpp
+++ b/ReClass/CNodeHex64.cpp
@@ -14,11 +14,12 @@ void CNodeHex64::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)(Spot.Address + Spot.ID), &v, 1 );
 }
 
-int CNodeHex64::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeHex64::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	unsigned char* pMemory = (unsigned char*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -44,5 +45,7 @@ int CNodeHex64::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crHex, 7, _T( "%0.2X" ), pMemory[7] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeHex64.h
+++ b/ReClass/CNodeHex64.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return 8; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeHex8.cpp
+++ b/ReClass/CNodeHex8.cpp
@@ -14,17 +14,18 @@ void CNodeHex8::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, 1 );
 }
 
-int CNodeHex8::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeHex8::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	unsigned char* pMemory = (unsigned char*)&((unsigned char*)View.pData)[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
 	AddTypeDrop( View, x, y );
 	//AddAdd(View,x,y);
-
+	
 	int tx = x + TXOFFSET + 16;
 	tx = AddAddressOffset( View, tx, y );
 
@@ -38,5 +39,7 @@ int CNodeHex8::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crHex, 0, _T( "%0.2X" ), pMemory[0] & 0xFF ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeHex8.h
+++ b/ReClass/CNodeHex8.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return 1; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeIcon.cpp
+++ b/ReClass/CNodeIcon.cpp
@@ -1,10 +1,15 @@
 #include "stdafx.h"
 #include "CNodeIcon.h"
 
-int CNodeIcon::Draw(ViewInfo & View, int x, int y)
+NodeSize CNodeIcon::Draw(ViewInfo & View, int x, int y)
 {
+	NodeSize drawnSize;
+	
 	for (UINT i = 0; i < 21; i++)
 		x = AddIcon(View, x, y, i, -1, -1);
-	return y += g_FontHeight;
+	
+	drawnSize.x = x;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }
 

--- a/ReClass/CNodeIcon.h
+++ b/ReClass/CNodeIcon.h
@@ -5,6 +5,6 @@
 class CNodeIcon : public CNodeBase
 {
 public:
-	virtual int Draw(ViewInfo& View, int x, int y);
+	virtual NodeSize Draw(ViewInfo& View, int x, int y);
 };
 

--- a/ReClass/CNodeInt16.cpp
+++ b/ReClass/CNodeInt16.cpp
@@ -14,11 +14,12 @@ void CNodeInt16::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( short ) );
 }
 
-int CNodeInt16::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeInt16::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	__int16* pMemory = (__int16*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -34,5 +35,7 @@ int CNodeInt16::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%i" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeInt16.h
+++ b/ReClass/CNodeInt16.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( short ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeInt32.cpp
+++ b/ReClass/CNodeInt32.cpp
@@ -14,11 +14,12 @@ void CNodeInt32::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( long ) );
 }
 
-int CNodeInt32::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeInt32::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	__int32* pMemory = (__int32*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -34,5 +35,7 @@ int CNodeInt32::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%i" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeInt32.h
+++ b/ReClass/CNodeInt32.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( long ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeInt64.cpp
+++ b/ReClass/CNodeInt64.cpp
@@ -14,11 +14,12 @@ void CNodeInt64::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( __int64 ) );
 }
 
-int CNodeInt64::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeInt64::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	__int64 Int64 = *(__int64*)(&View.pData[m_Offset]);
 
 	AddSelection( View, 0, y, g_FontHeight );
@@ -35,5 +36,7 @@ int CNodeInt64::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%lli" ), Int64 ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeInt64.h
+++ b/ReClass/CNodeInt64.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( __int64 ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeInt8.cpp
+++ b/ReClass/CNodeInt8.cpp
@@ -14,11 +14,12 @@ void CNodeInt8::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( char ) );
 }
 
-int CNodeInt8::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeInt8::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	__int8* pMemory = (__int8*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -34,5 +35,7 @@ int CNodeInt8::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%i" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeInt8.h
+++ b/ReClass/CNodeInt8.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( char ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeMatrix.cpp
+++ b/ReClass/CNodeMatrix.cpp
@@ -16,11 +16,12 @@ void CNodeMatrix::Update( HotSpot & Spot )
 	}
 }
 
-int CNodeMatrix::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeMatrix::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	float* pMemory = (float*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -84,5 +85,7 @@ int CNodeMatrix::Draw( ViewInfo & View, int x, int y )
 		tx = AddText( View, tx, y, g_crName, HS_NONE, _T( "|" ) );
 	}
 
-	return y + g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeMatrix.h
+++ b/ReClass/CNodeMatrix.h
@@ -9,5 +9,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return 4 * 4 * sizeof( float ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodePtr.cpp
+++ b/ReClass/CNodePtr.cpp
@@ -11,11 +11,13 @@ void CNodePtr::Update( HotSpot & Spot )
 	StandardUpdate( Spot );
 }
 
-int CNodePtr::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodePtr::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize = { 0 };
+	NodeSize childDrawnSize;
 	ULONG_PTR* pMemory = (ULONG_PTR*)&View.pData[m_Offset];
 
 	//printf( "read ptr: %p\n", View.pData );
@@ -37,7 +39,7 @@ int CNodePtr::Draw( ViewInfo & View, int x, int y )
 	tx = AddComment( View, tx, y );
 
 	y += g_FontHeight;
-
+	drawnSize.x = tx;
 	if (m_LevelsOpen[View.Level])
 	{
 		DWORD NeededSize = m_pNode->GetMemorySize( );
@@ -50,7 +52,14 @@ int CNodePtr::Draw( ViewInfo & View, int x, int y )
 
 		ReClassReadMemory( (LPVOID)newView.Address, (LPVOID)newView.pData, NeededSize );
 
-		y = m_pNode->Draw( newView, x, y );
+		childDrawnSize = m_pNode->Draw( newView, x, y );
+		y = childDrawnSize.y;
+		if (childDrawnSize.x > drawnSize.x) {
+			drawnSize.x = childDrawnSize.x;
+		}
+
 	}
-	return y;
+
+	drawnSize.y = y;
+	return drawnSize;
 }

--- a/ReClass/CNodePtr.h
+++ b/ReClass/CNodePtr.h
@@ -12,7 +12,7 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( void* ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	void SetClass( CNodeClass* pNode ) { m_pNode = pNode; }
 	CNodeClass* GetClass( void ) { return m_pNode; }

--- a/ReClass/CNodeQWORD.cpp
+++ b/ReClass/CNodeQWORD.cpp
@@ -14,11 +14,12 @@ void CNodeQWORD::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( unsigned long long ) );
 }
 
-int CNodeQWORD::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeQWORD::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	DWORD64* pMemory = (DWORD64*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -34,5 +35,7 @@ int CNodeQWORD::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%llu" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeQWORD.h
+++ b/ReClass/CNodeQWORD.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( unsigned long long ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeQuat.cpp
+++ b/ReClass/CNodeQuat.cpp
@@ -16,11 +16,12 @@ void CNodeQuat::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)(Spot.Address + (Spot.ID * sizeof( float ))), &v, sizeof( float ) );
 }
 
-int CNodeQuat::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeQuat::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	float* pMemory = (float*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -47,5 +48,7 @@ int CNodeQuat::Draw( ViewInfo & View, int x, int y )
 	tx += g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y + g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeQuat.h
+++ b/ReClass/CNodeQuat.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( float ) * 4; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeText.cpp
+++ b/ReClass/CNodeText.cpp
@@ -25,9 +25,10 @@ void CNodeText::Update( HotSpot& Spot )
 	}
 }
 
-int CNodeText::Draw( ViewInfo& View, int x, int y )
+NodeSize CNodeText::Draw( ViewInfo& View, int x, int y )
 {
 	PCHAR pMemory = NULL;
+	NodeSize drawnSize;
 
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
@@ -56,5 +57,7 @@ int CNodeText::Draw( ViewInfo& View, int x, int y )
 	}
 
 	tx = AddComment( View, tx, y );
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeText.h
+++ b/ReClass/CNodeText.h
@@ -11,7 +11,7 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return m_dwMemorySize; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	void SetSize( DWORD size ) { m_dwMemorySize = size; }
 	DWORD GetSize( void ) { return m_dwMemorySize; }

--- a/ReClass/CNodeUnicode.cpp
+++ b/ReClass/CNodeUnicode.cpp
@@ -33,11 +33,12 @@ void CNodeUnicode::Update( HotSpot & Spot )
 	}
 }
 
-int CNodeUnicode::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeUnicode::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	wchar_t* pMemory = (wchar_t*)&((unsigned char*)View.pData)[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -62,5 +63,8 @@ int CNodeUnicode::Draw( ViewInfo & View, int x, int y )
 	}
 
 	tx = AddComment( View, tx, y );
-	return y += g_FontHeight;
+
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeUnicode.h
+++ b/ReClass/CNodeUnicode.h
@@ -11,7 +11,7 @@ public:
 
 	virtual ULONG GetMemorySize( void ) { return m_dwMemorySize; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 	void SetSize( DWORD size ) { m_dwMemorySize = size; }
 	DWORD GetSize( void ) { return m_dwMemorySize; }

--- a/ReClass/CNodeVTable.cpp
+++ b/ReClass/CNodeVTable.cpp
@@ -11,12 +11,14 @@ void CNodeVTable::Update( HotSpot & Spot )
 	StandardUpdate( Spot );
 }
 
-int CNodeVTable::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeVTable::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
 	ULONG_PTR* pMemory = (ULONG_PTR*)&View.pData[m_Offset];
+	NodeSize drawnSize = { 0 };
+	NodeSize childDrawnSize = { 0 };
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
 	AddTypeDrop( View, x, y );
@@ -36,6 +38,9 @@ int CNodeVTable::Draw( ViewInfo & View, int x, int y )
 	x = AddComment( View, x, y );
 
 	y += g_FontHeight;
+	drawnSize.x = x;
+	drawnSize.y = y;
+
 	if (m_LevelsOpen[View.Level])
 	{
 		ViewInfo NewView;
@@ -52,9 +57,15 @@ int CNodeVTable::Draw( ViewInfo & View, int x, int y )
 		for (UINT i = 0; i < Nodes.size( ); i++)
 		{
 			Nodes[i]->SetOffset( i * sizeof( size_t ) );
-			y = Nodes[i]->Draw( NewView, tx, y );
-		}
-	}
+			childDrawnSize = Nodes[i]->Draw( NewView, tx, y );
+			drawnSize.y = childDrawnSize.y;
+			if (childDrawnSize.x > drawnSize.x) {
+				drawnSize.x = childDrawnSize.x;
+			}
 
-	return y;
+			y = drawnSize.y;
+		}
+	}		
+
+	return drawnSize;
 }

--- a/ReClass/CNodeVTable.h
+++ b/ReClass/CNodeVTable.h
@@ -12,7 +12,7 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( void* ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 private:
 	CMemory m_Memory;

--- a/ReClass/CNodeVec2.cpp
+++ b/ReClass/CNodeVec2.cpp
@@ -16,11 +16,12 @@ void CNodeVec2::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)(Spot.Address + (Spot.ID * 4)), &v, 4 );
 }
 
-int CNodeVec2::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeVec2::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize;
 	float* pMemory = (float*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -42,5 +43,8 @@ int CNodeVec2::Draw( ViewInfo & View, int x, int y )
 	}
 	tx += g_FontWidth;
 	tx = AddComment( View, tx, y );
-	return (y + g_FontHeight);
+
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeVec2.h
+++ b/ReClass/CNodeVec2.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( float ) * 2; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeVec3.cpp
+++ b/ReClass/CNodeVec3.cpp
@@ -16,11 +16,12 @@ void CNodeVec3::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)(Spot.Address + (Spot.ID * sizeof( float ))), &v, sizeof( float ) );
 }
 
-int CNodeVec3::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeVec3::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize = { 0 };
 	float* pMemory = (float*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -44,6 +45,8 @@ int CNodeVec3::Draw( ViewInfo & View, int x, int y )
 	}
 	tx += g_FontWidth;
 	tx = AddComment( View, tx, y );
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
 
-	return y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeVec3.h
+++ b/ReClass/CNodeVec3.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( float ) * 3; }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };

--- a/ReClass/CNodeWCharPtr.cpp
+++ b/ReClass/CNodeWCharPtr.cpp
@@ -15,10 +15,11 @@ void CNodeWCharPtr::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( size_t ) );
 }
 
-int CNodeWCharPtr::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeWCharPtr::Draw( ViewInfo & View, int x, int y )
 {
 	int tx = 0;
 	ULONG_PTR* pMemory = NULL;
+	NodeSize drawnSize = { 0 };
 
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
@@ -61,5 +62,9 @@ int CNodeWCharPtr::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crChar, HS_NONE, _T( "' " ) ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+
+	return drawnSize;
 }

--- a/ReClass/CNodeWCharPtr.h
+++ b/ReClass/CNodeWCharPtr.h
@@ -12,7 +12,7 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( void* ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 
 public:
 	CNodeBase* pNode;

--- a/ReClass/CNodeWORD.cpp
+++ b/ReClass/CNodeWORD.cpp
@@ -14,11 +14,12 @@ void CNodeWORD::Update( HotSpot & Spot )
 		ReClassWriteMemory( (LPVOID)Spot.Address, &v, sizeof( unsigned short ) );
 }
 
-int CNodeWORD::Draw( ViewInfo & View, int x, int y )
+NodeSize CNodeWORD::Draw( ViewInfo & View, int x, int y )
 {
 	if (m_bHidden)
 		return DrawHidden( View, x, y );
 
+	NodeSize drawnSize = { 0 };
 	WORD* pMemory = (WORD*)&View.pData[m_Offset];
 	AddSelection( View, 0, y, g_FontHeight );
 	AddDelete( View, x, y );
@@ -34,5 +35,7 @@ int CNodeWORD::Draw( ViewInfo & View, int x, int y )
 	tx = AddText( View, tx, y, g_crValue, HS_EDIT, _T( "%u" ), pMemory[0] ) + g_FontWidth;
 	tx = AddComment( View, tx, y );
 
-	return y += g_FontHeight;
+	drawnSize.x = tx;
+	drawnSize.y = y + g_FontHeight;
+	return drawnSize;
 }

--- a/ReClass/CNodeWORD.h
+++ b/ReClass/CNodeWORD.h
@@ -11,5 +11,5 @@ public:
 
 	virtual ULONG GetMemorySize( ) { return sizeof( unsigned short ); }
 
-	virtual int Draw( ViewInfo& View, int x, int y );
+	virtual NodeSize Draw( ViewInfo& View, int x, int y );
 };


### PR DESCRIPTION
…e *total* instead of one for each node, reducing hidden bar spam

The horizontal scroll bar was added and put in the resize routines and all that.  In order to make it scroll properly, I made the node->Draw() routines return a tuple representing the x size of the drawn node as well as the y size, whereas previously it was just the y size.  Each node that draws other nodes keeps track of the max x size of the nodes it draws, and returns that value as its own x size.  That way when we get back up to the top node, we have the width of the longest node as well as the total height in nodes that we've drawn.

I did this because there have been situations where I've needed to use Reclass on small resolution screens where I also had to navigate long linked lists.  So every so many links I went through, I had to copy the address and start a new tab to start viewing the list from there.  that suxxxxxx

Also, whereas before it would draw a 1 height grey line for each hidden node, I made it only draw a 1 height grey line for any number of adjacent hidden nodes.  This is because I'd hide like 1000 nodes and then get big thick grey lines.