### PR TITLE
Fix CNodeFunctionPtr's destructor not being invoked on deletion

### DIFF
--- a/ReClass/CNodeBase.h
+++ b/ReClass/CNodeBase.h
@@ -106,7 +106,7 @@ typedef struct _NODESIZE {
 class CNodeBase {
 public:
 	CNodeBase( );
-	~CNodeBase( ) { }
+	virtual ~CNodeBase( ) { }
 
 	virtual NODESIZE Draw( const PVIEWINFO View, int x, int y ) = 0;
 	virtual ULONG GetMemorySize( ) = 0;


### PR DESCRIPTION
`~CNodeFunctionPtr::CNodeFunctionPtr()` is not being invoked when deleting a function pointer node resulting in disassembly being permanently shown on a tab. Here's a before/after when deleting a function pointer node:

![Before deletion.](https://i.imgur.com/d3ykzbo.png)
![After deletion.](https://i.imgur.com/94ECxkG.png)